### PR TITLE
Check for valid handler type

### DIFF
--- a/config.go
+++ b/config.go
@@ -83,6 +83,15 @@ func (c Config) getGraylogHandlerType() graylog.Transport {
 		transportType = graylog.UDP
 	}
 
+	if transportType == "" {
+		panic(
+			fmt.Errorf(
+				"no valid GRAYLOG_HANDLER_TYPE set \"%s\"; expected \"tls\" or \"udp\"",
+				handlerType,
+			),
+		)
+	}
+
 	return transportType
 }
 


### PR DESCRIPTION
Make sure when parsing the `GRAYLOG_HANDLER_TYPE` that if it's not `tls` or `udp` than panic.