### PR TITLE
Feature/fix env usage

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,6 +41,7 @@ func (e EnvConfig) getGraylogAppName() string {
 }
 
 func (e *EnvConfig) getGraylogHandlerType() graylog.Transport {
+	defaultHandlerType := tlsTransport
 	handlerType := os.Getenv("GRAYLOG_HANDLER_TYPE")
 	if handlerType == "" {
 		panic("GRAYLOG_HANDLER_TYPE env not set")
@@ -55,13 +56,9 @@ func (e *EnvConfig) getGraylogHandlerType() graylog.Transport {
 		transportType = graylog.UDP
 	}
 
+	// If no transport type is set use tls by default.
 	if transportType == "" {
-		panic(
-			fmt.Errorf(
-				"no valid GRAYLOG_HANDLER_TYPE set \"%s\"; expected \"tls\" or \"udp\"",
-				handlerType,
-			),
-		)
+		transportType = graylog.Transport(defaultHandlerType)
 	}
 
 	return transportType

--- a/config.go
+++ b/config.go
@@ -28,9 +28,7 @@ type Config interface {
 
 // EnvConfig represents all the logger configurations available
 // when instaniating a new Logger.
-type EnvConfig struct {
-	logEnvName *string
-}
+type EnvConfig struct{}
 
 func (e EnvConfig) getGraylogAppName() string {
 	appName := os.Getenv("GRAYLOG_APP_NAME")
@@ -125,18 +123,10 @@ func (e *EnvConfig) getGraylogTLSTimeout() time.Duration {
 }
 
 func (e *EnvConfig) getGraylogLogEnvName() string {
-	// Check if we already memoized the log env name.
-	if e.logEnvName != nil {
-		return *e.logEnvName
-	}
-
 	envName := os.Getenv("GRAYLOG_ENV")
 	if envName == "" {
 		panic("GRAYLOG_ENV not set")
 	}
-
-	// Memoize the log env name.
-	e.logEnvName = &envName
 
 	return envName
 }

--- a/config.go
+++ b/config.go
@@ -86,17 +86,14 @@ func (e *EnvConfig) useTLS() bool {
 }
 
 func (e *EnvConfig) getGraylogPort() uint {
-	var portString string
+	portString := "12201"
+
 	if e.getGraylogHandlerType() == graylog.UDP {
 		portString = os.Getenv("GRAYLOG_UDP_PORT")
 	}
 
 	if e.getGraylogHandlerType() == graylog.TCP {
 		portString = os.Getenv("GRAYLOG_TLS_PORT")
-	}
-
-	if portString == "" {
-		panic("GRAYLOG_UDP_PORT or GRAYLOG_TLS_PORT env not set")
 	}
 
 	port, err := strconv.ParseUint(portString, 10, 32)

--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ type Config interface {
 	getGraylogLogEnvName() string
 	getGraylogSkipInsecureSkipVerify() bool
 	getIsTestEnv() bool
+	useColoredConsolelogs() bool
 }
 
 // EnvConfig represents all the logger configurations available
@@ -143,6 +144,15 @@ func (e *EnvConfig) getGraylogSkipInsecureSkipVerify() bool {
 func (e *EnvConfig) getIsTestEnv() bool {
 	// If we're running test return test logger env.
 	if flag.Lookup("test.v") != nil {
+		return true
+	}
+
+	return false
+}
+
+func (e *EnvConfig) useColoredConsolelogs() bool {
+	envLevel := os.Getenv("THEMUSE_ENV_LEVEL")
+	if envLevel == "1" {
 		return true
 	}
 

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package gzap
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -11,32 +10,29 @@ import (
 	graylog "github.com/Devatoria/go-graylog"
 )
 
-const testEnv = 0
-const devEnv = 1
-const stagingEnv = 2
-const prodEnv = 3
-
 const tlsTransport = "tls"
 
-var envNotSetErrorString = "no valid env was explicity set, and not currently running tests"
-
-// Config represents all the logger configurations available
-// when instaniating a new Logger.
-type Config struct {
-	logEnvName      *string
-	_isMock         bool
-	_mockEnv        int
-	_mockEnvError   error
-	_mockGraylog    Graylog
-	_mockGraylogErr error
-	_mockDevErr     error
+// Config is an interface representing all the logging configurations accessible
+// via enironment
+type Config interface {
+	getGraylogAppName() string
+	getGraylogHandlerType() graylog.Transport
+	getGraylogHost() string
+	useTLS() bool
+	getGraylogPort() uint
+	getGraylogTLSTimeout() time.Duration
+	getGraylogLogEnvName() string
+	getGraylogSkipInsecureSkipVerify() bool
+	getIsTestEnv() bool
 }
 
-func (c Config) getGraylogAppName() string {
-	if c._isMock {
-		return ""
-	}
+// EnvConfig represents all the logger configurations available
+// when instaniating a new Logger.
+type EnvConfig struct {
+	logEnvName *string
+}
 
+func (e EnvConfig) getGraylogAppName() string {
 	appName := os.Getenv("GRAYLOG_APP_NAME")
 	if appName == "" {
 		panic("GRAYLOG_APP_NAME env not set")
@@ -45,30 +41,7 @@ func (c Config) getGraylogAppName() string {
 	return appName
 }
 
-func (c Config) getGraylogEnv() (int, error) {
-	if c._isMock {
-		return c._mockEnv, c._mockEnvError
-	}
-
-	// If we're running test return test logger env.
-	if flag.Lookup("test.v") != nil {
-		return testEnv, nil
-	}
-
-	envLevelString := os.Getenv("GRAYLOG_ENV")
-	if envLevelString == "" {
-		return 0, errors.New(envNotSetErrorString)
-	}
-
-	envLevel, err := strconv.Atoi(envLevelString)
-	if err != nil {
-		return 0, errors.New("could not properly parse GRAYLOG_ENV")
-	}
-
-	return envLevel, nil
-}
-
-func (c Config) getGraylogHandlerType() graylog.Transport {
+func (e *EnvConfig) getGraylogHandlerType() graylog.Transport {
 	handlerType := os.Getenv("GRAYLOG_HANDLER_TYPE")
 	if handlerType == "" {
 		panic("GRAYLOG_HANDLER_TYPE env not set")
@@ -95,16 +68,12 @@ func (c Config) getGraylogHandlerType() graylog.Transport {
 	return transportType
 }
 
-func (c Config) getGraylogHost() string {
+func (e *EnvConfig) getGraylogHost() string {
 	graylogHost := os.Getenv("GRAYLOG_HOST")
-	if graylogHost == "" {
-		panic("GRAYLOG_HOST env not set")
-	}
-
 	return graylogHost
 }
 
-func (c Config) useTLS() bool {
+func (e *EnvConfig) useTLS() bool {
 	handlerType := os.Getenv("GRAYLOG_HANDLER_TYPE")
 	if handlerType == "" {
 		panic("GRAYLOG_HANDLER_TYPE env not set")
@@ -117,13 +86,13 @@ func (c Config) useTLS() bool {
 	return false
 }
 
-func (c Config) getGraylogPort() uint {
+func (e *EnvConfig) getGraylogPort() uint {
 	var portString string
-	if c.getGraylogHandlerType() == graylog.UDP {
+	if e.getGraylogHandlerType() == graylog.UDP {
 		portString = os.Getenv("GRAYLOG_UDP_PORT")
 	}
 
-	if c.getGraylogHandlerType() == graylog.TCP {
+	if e.getGraylogHandlerType() == graylog.TCP {
 		portString = os.Getenv("GRAYLOG_TLS_PORT")
 	}
 
@@ -139,7 +108,7 @@ func (c Config) getGraylogPort() uint {
 	return uint(port)
 }
 
-func (c Config) getGraylogTLSTimeout() time.Duration {
+func (e *EnvConfig) getGraylogTLSTimeout() time.Duration {
 	defaultTimeout := time.Second * 3
 
 	timeoutString := os.Getenv("GRAYLOG_TLS_TIMEOUT_SECS")
@@ -155,35 +124,35 @@ func (c Config) getGraylogTLSTimeout() time.Duration {
 	return time.Second * time.Duration(timeoutSeconds)
 }
 
-func (c Config) getGraylogLogEnvName() string {
+func (e *EnvConfig) getGraylogLogEnvName() string {
 	// Check if we already memoized the log env name.
-	if c.logEnvName != nil {
-		return *c.logEnvName
+	if e.logEnvName != nil {
+		return *e.logEnvName
 	}
 
-	env, err := c.getGraylogEnv()
-	if err != nil {
-		panic(err)
-	}
-
-	var logEnvName string
-	if env == prodEnv {
-		logEnvName = "prd"
-	}
-
-	if env == stagingEnv {
-		logEnvName = "stg"
+	envName := os.Getenv("GRAYLOG_ENV")
+	if envName == "" {
+		panic("GRAYLOG_ENV not set")
 	}
 
 	// Memoize the log env name.
-	c.logEnvName = &logEnvName
+	e.logEnvName = &envName
 
-	return logEnvName
+	return envName
 }
 
-func (c Config) getGraylogSkipInsecureSkipVerify() bool {
+func (e *EnvConfig) getGraylogSkipInsecureSkipVerify() bool {
 	skipInsecure := os.Getenv("GRAYLOG_SKIP_TLS_VERIFY")
 	if skipInsecure == "true" {
+		return true
+	}
+
+	return false
+}
+
+func (e *EnvConfig) getIsTestEnv() bool {
+	// If we're running test return test logger env.
+	if flag.Lookup("test.v") != nil {
 		return true
 	}
 

--- a/config.go
+++ b/config.go
@@ -43,9 +43,6 @@ func (e EnvConfig) getGraylogAppName() string {
 func (e *EnvConfig) getGraylogHandlerType() graylog.Transport {
 	defaultHandlerType := tlsTransport
 	handlerType := os.Getenv("GRAYLOG_HANDLER_TYPE")
-	if handlerType == "" {
-		panic("GRAYLOG_HANDLER_TYPE env not set")
-	}
 
 	var transportType graylog.Transport
 	if handlerType == tlsTransport {

--- a/gelfcore.go
+++ b/gelfcore.go
@@ -110,6 +110,7 @@ func (gc GelfCore) With(fields []zapcore.Field) zapcore.Core {
 		Graylog: gc.Graylog,
 		Context: append(gc.Context, fields...),
 		encoder: gc.encoder,
+		cfg:     gc.cfg,
 	}
 }
 

--- a/gelfcore_test.go
+++ b/gelfcore_test.go
@@ -33,9 +33,7 @@ func TestGelfCore_Write(t *testing.T) {
 			fields{
 				&MockGraylog{},
 				[]zapcore.Field{},
-				Config{
-					_isMock: true,
-				},
+				&MockEnvConfig{},
 			},
 			args{
 				zapcore.Entry{},
@@ -50,9 +48,7 @@ func TestGelfCore_Write(t *testing.T) {
 			fields{
 				&MockGraylog{},
 				[]zapcore.Field{},
-				Config{
-					_isMock: true,
-				},
+				&MockEnvConfig{},
 			},
 			args{
 				zapcore.Entry{},
@@ -65,9 +61,14 @@ func TestGelfCore_Write(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewMockGraylog()
-			m.On("Send", mock.AnythingOfType("graylog.Message")).Return(tt.sendErr)
-			tt.fields.Graylog = &m
+			mockGraylog := NewMockGraylog()
+			mockGraylog.On("Send", mock.AnythingOfType("graylog.Message")).Return(tt.sendErr)
+			tt.fields.Graylog = &mockGraylog
+
+			mockEnvConfig := &MockEnvConfig{}
+			mockEnvConfig.On("getGraylogAppName").Return("LOL")
+			mockEnvConfig.On("getIsTestEnv").Return(false)
+			tt.fields.cfg = mockEnvConfig
 
 			gc := GelfCore{
 				Graylog: tt.fields.Graylog,

--- a/gelfcore_test.go
+++ b/gelfcore_test.go
@@ -66,8 +66,7 @@ func TestGelfCore_Write(t *testing.T) {
 			tt.fields.Graylog = &mockGraylog
 
 			mockEnvConfig := &MockEnvConfig{}
-			mockEnvConfig.On("getGraylogAppName").Return("LOL")
-			mockEnvConfig.On("getIsTestEnv").Return(false)
+			mockEnvConfig.On("getGraylogAppName").Return("TEST")
 			tt.fields.cfg = mockEnvConfig
 
 			gc := GelfCore{

--- a/graylog.go
+++ b/graylog.go
@@ -16,10 +16,6 @@ type Graylog interface {
 
 // NewGraylog returns a new Graylog instance.
 func NewGraylog(cfg Config) (Graylog, error) {
-	if cfg._isMock {
-		return cfg._mockGraylog, cfg._mockGraylogErr
-	}
-
 	var gl Graylog
 	var err error
 

--- a/gzap_test.go
+++ b/gzap_test.go
@@ -44,6 +44,7 @@ func TestInitLogger(t *testing.T) {
 			cfg.On("getGraylogHost").Return(tt.args.graylogHost)
 			cfg.On("getGraylogHandlerType").Return(tt.args.graylogHandlerType)
 			cfg.On("getGraylogLogEnvName").Return(tt.args.graylogLogEnvName)
+			cfg.On("useColoredConsolelogs").Return(true)
 
 			err := initLogger(&cfg)
 

--- a/gzap_test.go
+++ b/gzap_test.go
@@ -1,13 +1,18 @@
 package gzap
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/Devatoria/go-graylog"
 )
 
 func TestInitLogger(t *testing.T) {
 	type args struct {
-		cfg Config
+		graylogAppName     string
+		isTestEnv          bool
+		graylogHost        string
+		graylogHandlerType graylog.Transport
+		graylogLogEnvName  string
 	}
 	tests := []struct {
 		name    string
@@ -16,115 +21,31 @@ func TestInitLogger(t *testing.T) {
 		err     string
 	}{
 		{
-			"Init should fail if Graylog fails to connect with Prod configuration",
+			"InitLogger should return a noop logger when running a test",
 			args{
-				Config{
-					_isMock:         true,
-					_mockEnv:        prodEnv,
-					_mockGraylogErr: errors.New("could not connect to Graylog"),
-				},
-			},
-			true,
-			"could not connect to Graylog",
-		},
-		{
-			"initLogger should pass if Graylog connects with Prod configuration",
-			args{
-				Config{
-					_isMock:         true,
-					_mockEnv:        prodEnv,
-					_mockGraylog:    &MockGraylog{},
-					_mockGraylogErr: nil,
-				},
+				isTestEnv: true,
 			},
 			false,
 			"",
 		},
 		{
-			"initLogger should fail if Graylog fails to connect with Staging configuration",
-			args{
-				Config{
-					_isMock:         true,
-					_mockEnv:        stagingEnv,
-					_mockGraylogErr: errors.New("could not connect to Graylog"),
-				},
-			},
-			true,
-			"could not connect to Graylog",
-		},
-		{
-			"initLogger should pass if Graylog connects with Staging configuration",
-			args{
-				Config{
-					_isMock:         true,
-					_mockEnv:        stagingEnv,
-					_mockGraylog:    &MockGraylog{},
-					_mockGraylogErr: nil,
-				},
-			},
+			"InitLogger should return a dev logger when no GRAYLOG_HOST is set",
+			args{},
 			false,
 			"",
-		},
-		{
-			"initLogger should pass if using test configuration",
-			args{
-				Config{
-					_isMock:  true,
-					_mockEnv: testEnv,
-				},
-			},
-			false,
-			"",
-		},
-		{
-			"initLogger should pass if using dev configuration",
-			args{
-				Config{
-					_isMock:  true,
-					_mockEnv: devEnv,
-				},
-			},
-			false,
-			"",
-		},
-		{
-			"initLogger should fail if invalid configuration is passed",
-			args{
-				Config{
-					_isMock:  true,
-					_mockEnv: 99,
-				},
-			},
-			true,
-			"no valid env was explicity set, and not currently running tests",
-		},
-		{
-			"initLogger should fail if it cannot parse GRAYLOG_ENV",
-			args{
-				Config{
-					_isMock:       true,
-					_mockEnvError: errors.New("error occured when parsing env"),
-				},
-			},
-			true,
-			"error occured when parsing env",
-		},
-		{
-			"initLogger should fail if dev logger throws error",
-			args{
-				Config{
-					_isMock:     true,
-					_mockEnv:    devEnv,
-					_mockDevErr: errors.New("could not build development logger"),
-				},
-			},
-			true,
-			"could not build development logger",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := initLogger(tt.args.cfg)
+			// Instaniate new MockEnvConfig.
+			cfg := MockEnvConfig{}
+			cfg.On("getGraylogAppName").Return(tt.args.graylogAppName)
+			cfg.On("getIsTestEnv").Return(tt.args.isTestEnv)
+			cfg.On("getGraylogHost").Return(tt.args.graylogHost)
+			cfg.On("getGraylogHandlerType").Return(tt.args.graylogHandlerType)
+			cfg.On("getGraylogLogEnvName").Return(tt.args.graylogLogEnvName)
+
+			err := initLogger(&cfg)
 
 			if tt.wantErr && err == nil {
 				t.Errorf("initLogger() expected error = \"%v\"; got \"nil\"", tt.err)

--- a/mock_config.go
+++ b/mock_config.go
@@ -1,0 +1,59 @@
+package gzap
+
+import (
+	"time"
+
+	graylog "github.com/Devatoria/go-graylog"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockEnvConfig represents all the logger configurations available
+// when instaniating a new Logger via a mock.
+type MockEnvConfig struct {
+	mock.Mock
+}
+
+func (m *MockEnvConfig) getGraylogAppName() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockEnvConfig) getGraylogHandlerType() graylog.Transport {
+	args := m.Called()
+	return args.Get(0).(graylog.Transport)
+}
+
+func (m *MockEnvConfig) getGraylogHost() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockEnvConfig) useTLS() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockEnvConfig) getGraylogPort() uint {
+	args := m.Called()
+	return args.Get(0).(uint)
+}
+
+func (m *MockEnvConfig) getGraylogTLSTimeout() time.Duration {
+	args := m.Called()
+	return args.Get(0).(time.Duration)
+}
+
+func (m *MockEnvConfig) getGraylogLogEnvName() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockEnvConfig) getGraylogSkipInsecureSkipVerify() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockEnvConfig) getIsTestEnv() bool {
+	args := m.Called()
+	return args.Bool(0)
+}

--- a/mock_config.go
+++ b/mock_config.go
@@ -57,3 +57,8 @@ func (m *MockEnvConfig) getIsTestEnv() bool {
 	args := m.Called()
 	return args.Bool(0)
 }
+
+func (m *MockEnvConfig) useColoredConsolelogs() bool {
+	args := m.Called()
+	return args.Bool(0)
+}


### PR DESCRIPTION
- We now determine which logger to initialize based on the presents of `GRAYLOG_HOST`. If `GRAYLOG_HOST` is empty we just use a console logger, if `GRAYLOG_HOST` is set we use a console logger + Graylog.

- Created a `MockEnvConfig`

- Use whatever user provides for `GRAYLOG_ENV` unless it's empty, then it will panic