### PR TITLE
Add a type for leveled loggers

### DIFF
--- a/gzap.go
+++ b/gzap.go
@@ -7,6 +7,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// LevedLogger is a unifying type for all of the exported zap leveled loggers,
+// Info, Warn, Error, Debug.
+type LevedLogger func(msg string, fields ...zapcore.Field)
+
 // Logger is the global logger for the application. Upon first initalization of
 // the logger all calls to 'getLogger' are memoized with the instantiated 'logger'.
 var Logger = getLogger()


### PR DESCRIPTION
We need this so we can dynamically use leveled loggers depending on evaluation. (I.E: use an `INFO`, `WARN`, or `ERROR` logger depending on the response code status we're returning to a client.)