### PR TITLE
Remove panics for initializing logger and sending logs to graylog

### DIFF
--- a/gelfcore.go
+++ b/gelfcore.go
@@ -3,6 +3,7 @@ package gzap
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 
@@ -103,7 +104,9 @@ func (gc GelfCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 
 	if err := gc.Graylog.Send(msg); err != nil {
 		if err := attemptRetry(gc.cfg, gc, msg, gc.graylogConstructor); err != nil {
-			panic(err)
+			// If the re-attempt fails to send the log to Graylog, simply log it to STDOUT. We
+			// do not want to panic here as it can bring down the cluster unnecessarily.
+			log.Printf("Gzap failed to send a log to Graylog:\n\terror: %+v\n\tmessage: %+v\n", err, msg)
 		}
 	}
 

--- a/gzap_test.go
+++ b/gzap_test.go
@@ -46,7 +46,7 @@ func TestInitLogger(t *testing.T) {
 			cfg.On("getGraylogLogEnvName").Return(tt.args.graylogLogEnvName)
 			cfg.On("useColoredConsolelogs").Return(true)
 
-			err := initLogger(&cfg)
+			err := initLogger(&cfg, false)
 
 			if tt.wantErr && err == nil {
 				t.Errorf("initLogger() expected error = \"%v\"; got \"nil\"", tt.err)


### PR DESCRIPTION
Removes the use of panics when the logger cannot be instantiated or if a message cannot be sent.